### PR TITLE
fix: client seeing server as incompatible

### DIFF
--- a/src/main/java/me/srrapero720/watermedia/core/WaterForgeLoader.java
+++ b/src/main/java/me/srrapero720/watermedia/core/WaterForgeLoader.java
@@ -1,10 +1,13 @@
 package me.srrapero720.watermedia.core;
 
 import me.srrapero720.watermedia.WaterMedia;
+import net.minecraftforge.fml.IExtensionPoint;
+import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.fml.loading.FMLLoader;
 import net.minecraftforge.fml.loading.FMLPaths;
+import net.minecraftforge.network.NetworkConstants;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 
@@ -29,5 +32,8 @@ public class WaterForgeLoader {
             if (FMLLoader.isProduction()) throw new IllegalStateException("REMOVE WATERMeDIA FROM SERVER_SIDE, THIS IS A CLIENT_SIDE MOD!!!");
             else LOGGER.warn(IT, "Developer environment detected, ignoring crashes");
         } else WaterMedia.load(FMLPaths.GAMEDIR.get());
+
+        //Make sure the mod being absent on the other network side does not cause the client to display the server as incompatible
+        ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class, () -> new IExtensionPoint.DisplayTest(() -> NetworkConstants.IGNORESERVERONLY, (a, b) -> true));
     }
 }


### PR DESCRIPTION
Currently the mod makes the minecraft client show servers as incompatible.
I just added the last snippet found in minecraftforge [doc](https://docs.minecraftforge.net/en/latest/concepts/sides/#writing-one-sided-mods).

Before
![before](https://github.com/SrRapero720/watermedia/assets/12870834/bf2b1a26-7c0e-4c35-9e21-47a0c9b9266f)

After
![after](https://github.com/SrRapero720/watermedia/assets/12870834/05343c5f-6c7e-44ba-b110-263cba1551f7)
