### PR TITLE
Fix PBO implementation

### DIFF
--- a/src/main/java/me/srrapero720/watermedia/api/image/ImageRenderer.java
+++ b/src/main/java/me/srrapero720/watermedia/api/image/ImageRenderer.java
@@ -81,12 +81,12 @@ public class ImageRenderer {
      * @see ImageRenderer#texture(int, long, boolean) too
      */
     public int texture(long time) {
-        int last = texture(0);
-        for (int i = 1; i < delay.length; i++) {
-            if (delay[i] > time) break;
-            last = texture(i);
+        for (int i = 0; i < delay.length; i++) {
+            time -= delay[i];
+            if (time <= 0)
+                return texture(i);
         }
-        return last;
+        return texture(images.length - 1);
     }
 
     /**

--- a/src/main/java/me/srrapero720/watermedia/api/image/ImageRenderer.java
+++ b/src/main/java/me/srrapero720/watermedia/api/image/ImageRenderer.java
@@ -101,7 +101,7 @@ public class ImageRenderer {
 
         // COPY TO PBO
         pbo = GL15.glMapBuffer(GL21.GL_PIXEL_UNPACK_BUFFER, GL15.GL_WRITE_ONLY, this.width * this.height * 4L, pbo);
-        RenderAPI.putImageByteBuffer(pbo, images[index], 0, 0);
+        RenderAPI.putImageByteBuffer(pbo, images[index]);
         GL15.glUnmapBuffer(GL21.GL_PIXEL_UNPACK_BUFFER);
 
         // PARAMS
@@ -110,7 +110,7 @@ public class ImageRenderer {
         GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, GL12.GL_CLAMP_TO_EDGE);
         GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR);
         GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_LINEAR);
-        GL11.glTexImage2D(GL11.GL_TEXTURE_2D, 0, GL11.GL_RGBA8, width, height, 0, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, 0);
+        GL11.glTexImage2D(GL11.GL_TEXTURE_2D, 0, GL11.GL_RGBA8, width, height, 0, GL12.GL_BGRA, GL12.GL_UNSIGNED_INT_8_8_8_8_REV, 0);
 
         // UNBIND PBO
         GL21.glBindBuffer(GL21.GL_PIXEL_UNPACK_BUFFER, 0);

--- a/src/main/java/me/srrapero720/watermedia/api/image/ImageRenderer.java
+++ b/src/main/java/me/srrapero720/watermedia/api/image/ImageRenderer.java
@@ -180,6 +180,7 @@ public class ImageRenderer {
      */
     public void release() {
         GL11.glDeleteTextures(texture);
+        GL21.glDeleteBuffers(pboId);
         flush();
     }
 }


### PR DESCRIPTION
Fixes the following issues:
- The PBO not being unmap before calling glTexImage2D
- `glTexImage2D` being asked to copy from the PBO, but no buffer is bound to `GL_PIXEL_UNPACK_BUFFER`
- `glBufferData` being called to copy the mapped buffer into itself
- Images were being uploaded even if they've already been uploaded when texture() is called repeatedly with the same index
- Color channels were reversed due to images using BGRA internally

I also went back to `getRGB()` as in the end it's more reliable to have it deal with any color model conversions to BGRA, which we would have to do ourselves if we use the data buffer directly from the raster. (Grayscale images having only one channel for example)