### PR TITLE
Add SHA256 digest to cached file name

### DIFF
--- a/src/main/java/me/srrapero720/watermedia/api/cache/CacheAPI.java
+++ b/src/main/java/me/srrapero720/watermedia/api/cache/CacheAPI.java
@@ -3,11 +3,15 @@ package me.srrapero720.watermedia.api.cache;
 import me.srrapero720.watermedia.WaterMedia;
 import me.srrapero720.watermedia.api.WaterMediaAPI;
 import me.srrapero720.watermedia.loaders.ILoader;
+import me.srrapero720.watermedia.tools.IOTool;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 
 import java.io.*;
 import java.nio.file.Files;
+import java.security.NoSuchAlgorithmException;
+import java.security.MessageDigest;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
@@ -134,6 +138,12 @@ public class CacheAPI extends WaterMediaAPI {
     }
 
     static File entry$getFile(String url) {
-        return new File(dir, Base64.getEncoder().encodeToString(url.getBytes()));
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			return new File(dir, IOTool.encodeHexString(digest.digest(url.getBytes(StandardCharsets.UTF_8))));
+		} catch (NoSuchAlgorithmException e) { LOGGER.error(IT, "Failed to initalize digest", e); }
+
+		// Fallback to old naming
+		return new File(dir, Base64.getEncoder().encodeToString(url.getBytes()));
     }
 }

--- a/src/main/java/me/srrapero720/watermedia/tools/IOTool.java
+++ b/src/main/java/me/srrapero720/watermedia/tools/IOTool.java
@@ -105,4 +105,15 @@ public class IOTool {
             while ((read = zipIn.read(bytesIn)) != -1) output.write(bytesIn, 0, read);
         }
     }
+
+    private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
+    public static String encodeHexString(byte[] bytes) {
+        char[] hexChars = new char[bytes.length * 2];
+        for (int j = 0; j < bytes.length; j++) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = HEX_ARRAY[v >>> 4];
+            hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
+        }
+        return new String(hexChars);
+    }
 }


### PR DESCRIPTION
Replaces base64 encoding by SHA256 digest to generate cached files names.

Fixes caching failure when URL is too long (e.g. discord hosted ones).
Fixes illegal characters on Windows (namely '\\') that can show up in base64.

I also did a patch for the last release (2.0.31) : https://github.com/zFERDQFREZrzfq/watermedia/tree/patch-cache-2.0.31