### PR TITLE
Add SHA256 digest to cached file name (#61)

### DIFF
--- a/src/main/java/me/srrapero720/watermedia/core/CacheCore.java
+++ b/src/main/java/me/srrapero720/watermedia/core/CacheCore.java
@@ -2,11 +2,15 @@ package me.srrapero720.watermedia.core;
 
 import me.srrapero720.watermedia.api.loader.IMediaLoader;
 import me.srrapero720.watermedia.core.tools.exceptions.ReInitException;
+import me.srrapero720.watermedia.tools.IOTool;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 
 import java.io.*;
 import java.nio.file.Files;
+import java.security.NoSuchAlgorithmException;
+import java.security.MessageDigest;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
@@ -73,7 +77,13 @@ public class CacheCore {
     }
 
     private static File entry$getFile(String url) {
-        return new File(dir, Base64.getEncoder().encodeToString(url.getBytes()));
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			return new File(dir, IOTool.encodeHexString(digest.digest(url.getBytes(StandardCharsets.UTF_8))));
+		} catch (NoSuchAlgorithmException e) { LOGGER.error(IT, "Failed to initalize digest", e); }
+
+		// Fallback to old naming
+		return new File(dir, Base64.getEncoder().encodeToString(url.getBytes()));
     }
 
     public static void saveFile(String url, String tag, long time, long expireTime, byte[] data) {

--- a/src/main/java/me/srrapero720/watermedia/tools/IOTool.java
+++ b/src/main/java/me/srrapero720/watermedia/tools/IOTool.java
@@ -1,0 +1,14 @@
+package me.srrapero720.watermedia.tools;
+
+public class IOTool {
+    private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
+    public static String encodeHexString(byte[] bytes) {
+        char[] hexChars = new char[bytes.length * 2];
+        for (int j = 0; j < bytes.length; j++) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = HEX_ARRAY[v >>> 4];
+            hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
+        }
+        return new String(hexChars);
+    }
+}


### PR DESCRIPTION
Fixes caching failure when URL is too long (e.g. discord hosted ones).
Fixes illegal characters on Windows (namely '\\') that can show up in base64.