### PR TITLE
putImageByteBuffer optimization.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,8 @@ run
 lib-tools
 lib-binaries
 
+# vscode
+.vscode
+
 # Files from Forge MDK
 forge*changelog.txt


### PR DESCRIPTION
I did this optimization to mitigate the huge FPS drop introduced with by 2.0.40.
I noticed 

I could not reproduce the GL error code mentioned by this [issue](https://github.com/SrRapero720/waterframes/issues/45) but I don't have any experience with GL to debug it anyway.

I also noticed that 2.0.40 introduced visual artefact on the pictures when the player moves but I think it's not related to this function. It happens quite randomly so it's hard to capture it, but it looks like the picture is mangled for 1 frame when it happens.